### PR TITLE
fix: resolve unused variable in MermaidRenderer

### DIFF
--- a/src/components/MermaidRenderer.tsx
+++ b/src/components/MermaidRenderer.tsx
@@ -28,7 +28,7 @@ const decodeHtmlEntities = (text: string): string => {
 const MermaidRenderer: React.FC<MermaidRendererProps> = ({ chart }) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = React.useState<string | null>(null);
-  const [error, setError] = React.useState<string | null>(null);
+  const [_error, setError] = React.useState<string | null>(null);
 
   useEffect(() => {
     const renderMermaid = async () => {


### PR DESCRIPTION
The 'error' state variable was declared but never read, causing a TypeScript build failure (TS6133).

Renamed to '_error' to indicate it is intentionally unused, resolving the build error.